### PR TITLE
Table formatting with "rich"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ You probably need to modify the list of `icinga_instances` and maybe the `notifi
 ## Usage
 
 ```
-usage: wtc.py [-h] --instance INSTANCE [--lookback LOOKBACK] [--limit LIMIT] [--filter FILTER] [--user USER] [--password PASSWORD]
-                               [--disable-urls] [--watch] [--watch-interval WATCH_INTERVAL]
+usage: wtc.py [-h] --instance INSTANCE [--lookback LOOKBACK] [--limit LIMIT] [--filter FILTER] [--user USER] [--password PASSWORD] [--show-urls] [--watch] [--watch-interval WATCH_INTERVAL] [--onetime ONETIME]
 
 options:
   -h, --help            show this help message and exit
@@ -19,17 +18,19 @@ options:
                         how long to look back for notifications (default: -1 days)
   --limit LIMIT         number of the last entries to display (default: 10)
   --filter FILTER       regex filter for notification contact name (default: .*)
-  --user USER, -u USER  Login User for Icinga (default: cise)
+  --user USER, -u USER  Login User for Icinga (default: current user login name)
   --password PASSWORD, -p PASSWORD
                         Login Password for Icinga (default: None)
-  --disable-urls
-  --watch               run the output in infinite loop, refreshing automatically (default: False)
+  --show-urls           show URLs instead of using xdg-open to open in the default browser (useful for remote shells etc) (default: False)
+  --watch, -w           run the output in infinite loop, refreshing automatically (default: False)
   --watch-interval WATCH_INTERVAL
                         interval for updates in watch mode in seconds (default: 120)
+  --onetime ONETIME, -o ONETIME
+                        only output calls once and exit afterwards (default: False)
 
-Args that start with '--' (eg. --instance) can also be set in a config file (~/.config/wtc.yml). The config file uses YAML syntax and must represent
-a YAML 'mapping' (for details, see http://learn.getgrav.org/advanced/yaml). If an arg is specified in more than one place, then commandline values override
-config file values which override defaults.
+Args that start with '--' (eg. --instance) can also be set in a config file (~/.config/wtc.yml). The config file uses YAML syntax and must represent a YAML 'mapping' (for details, see
+http://learn.getgrav.org/advanced/yaml). If an arg is specified in more than one place, then commandline values override config file values which override defaults.
+
 ```
 
 as described in the help output you can configure these settings via a configuration file in `~/.config/wtc.yml` as well.
@@ -51,24 +52,19 @@ filter: '.+call.+'
 ```plain
 user@host ~ % python3 wtc.py
 enter password for user:
-01 | 2023-02-21 16:15:51 | WARN | cust1-live-web02 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web02&service=cust1_disk
-02 | 2023-02-21 16:14:54 | WARN | cust1-live-web01 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web01&service=cust1_disk
-03 | 2023-02-21 15:46:54 | WARN | cust1-live-web01 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web01&service=cust1_disk
-04 | 2023-02-21 15:46:45 | WARN | cust1-live-web02 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web02&service=cust1_disk
-05 | 2023-02-21 15:26:54 | WARN | cust1-live-web01 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web01&service=cust1_disk
-06 | 2023-02-21 15:25:23 | WARN | cust1-live-web02 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-live-web02&service=cust1_disk
-07 | 2023-02-21 14:39:29 | CRIT | cust1-mgmt-sst01 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-mgmt-sst01&service=cust1_disk
-08 | 2023-02-21 14:33:55 | CRIT | cust2-live-web03 | cust2_cronjob_foo
-   `-https://icinga2.example.com/dashboard#!/monitoring/service/show?host=cust2-live-web03&service=cust2_cronjob_foo
-09 | 2023-02-21 14:29:52 | WARN | cust1-mgmt-sst01 | cust1_disk
-   `-https://icinga1.example.com/dashboard#!/monitoring/service/show?host=cust1-mgmt-sst01&service=cust1_disk
-10 | 2023-02-21 13:14:27 | CRIT | cust2-live-web02 | cust2_cronjob_bar
-   `-https://icinga2.example.com/dashboard#!/monitoring/service/show?host=cust2-live-web02&service=cust2_cronjob_bar
+  Numb…   Timestamp              State      Hostname                 Service
+ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  01      2023-05-24 09:09:23    CRITICAL   cust1-live-prx01         cust1_availability_haproxy_backends_live_prx
+  02      2023-05-24 09:08:45    CRITICAL   cust1-live-prx02         cust1_availability_haproxy_backends_live_prx
+  03      2023-05-24 03:07:28    WARNING    cust1-live-int01         cust1_availability_live_api_cust1-live-int01
+  04      2023-05-24 03:07:18    WARNING    cust1-live-int02         cust1_availability_live_api_cust1-live-int02
+  05      2023-05-24 03:05:40    CRITICAL   cust1-live-int02         cust1_mailrelay_rz1
+  06      2023-05-24 03:05:34    CRITICAL   cust1-live-int01         cust1_mailrelay_rz1
+  07      2023-05-24 03:04:50    UNKNOWN    hostp-lvirt-vc01.cust1   cust1_esx_host_datastore_cust1_test_fcc02
+  08      2023-05-24 03:02:49    UNKNOWN    hostp-lvirt-vc01.cust2   cust2_esx_host_datastore_fcc02
+  09      2023-05-24 03:01:07    UNKNOWN    hostp-lvirt-vc01.cust1   cust1_esx_host_datastore_cust1_live_fcc02
+  10      2023-05-24 03:00:42    UNKNOWN    hostp-lvirt-vc01.cust2   cust2_esx_host_datastore_fcc01
+
+press enter to refresh or enter a entry number to open the check in the web browser (using xdg-open):
+([0-9]|q)>
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ colorama>=0.4.6
 ConfigArgParse>=1.5.3
 PyYAML>=6.0
 requests>=2.28.2
+rich

--- a/wtc.py
+++ b/wtc.py
@@ -16,6 +16,8 @@ from getpass import getpass, getuser
 import configargparse
 from re import compile
 from colorama import Fore, Style, ansi
+from rich.console import Console
+from rich.table import Table, box
 
 def regex_parse(arg_value):
     """
@@ -97,28 +99,36 @@ def state_string(state):
 def text_output(notifications, limit: int):
     """generates text output from fetched notifications"""
     counter = 0
-    separator = " | "
+    table = Table(box=box.SIMPLE_HEAVY)
+    table.add_column("Number", style="dim", width=5)
+    table.add_column("Timestamp", width=20)
+    table.add_column("State")
+    table.add_column("Hostname")
+    table.add_column("Service")
     for r in notifications:
         timestamp = show_time(int(r.get("notification_timestamp")))
         hostname = r.get("host_name")
         service = r.get("service_display_name")
         url = r.get("url")
         state = state_string(r.get("notification_state"))
+        print(r.get("notification_state"))
+
 
         if r.get("notification_contact_name") != None:
             if args.filter.match(r.get("notification_contact_name")):
                 if counter < limit:
-                    output = separator.join([
+                    table.add_row(
                             f"{counter+1:02d}",
                             timestamp,
                             state,
                             hostname,
                             service
-                        ])
-                    print(output)
+                        )
+                    console.print(table)
                     if not args.disable_urls:
                         print(f'   `-{Fore.GREEN}{Style.BRIGHT}{url}{Style.RESET_ALL}')
                     counter += 1
+
                 else:
                     break
 
@@ -216,6 +226,9 @@ if __name__ == "__main__":
     )
 
     args = p.parse_args()
+
+    console = Console()
+
 
     # ask for password if it isn't set from the commandline
     if args.password is None:

--- a/wtc.py
+++ b/wtc.py
@@ -89,10 +89,10 @@ def show_time(ts):
 def state_string(state):
     """maps the state number (1-3) to colored text output"""
     states = {
-        '0': f'{Fore.GREEN}OK{Fore.RESET}',
-        '1': f'{Fore.YELLOW}WARN{Fore.RESET}',
-        '2': f'{Fore.RED}CRIT{Fore.RESET}',
-        '3': f'{Fore.CYAN}UNKN{Fore.RESET}'
+        '0': '[green]OK',
+        '1': '[yellow]WARNING',
+        '2': '[red]CRITICAL',
+        '3': '[cyan]UNKNOWN'
     }
     return states.get(state, state)
 
@@ -105,13 +105,13 @@ def text_output(notifications, limit: int):
     table.add_column("State")
     table.add_column("Hostname")
     table.add_column("Service")
+
     for r in notifications:
         timestamp = show_time(int(r.get("notification_timestamp")))
         hostname = r.get("host_name")
         service = r.get("service_display_name")
-        url = r.get("url")
         state = state_string(r.get("notification_state"))
-        print(r.get("notification_state"))
+        # print(r.get("notification_state"))
 
 
         if r.get("notification_contact_name") != None:
@@ -124,13 +124,12 @@ def text_output(notifications, limit: int):
                             hostname,
                             service
                         )
-                    console.print(table)
-                    if not args.disable_urls:
-                        print(f'   `-{Fore.GREEN}{Style.BRIGHT}{url}{Style.RESET_ALL}')
                     counter += 1
 
                 else:
                     break
+
+    console.print(table)
 
 def show_data():
     """fetches and outputs icinga notifications"""

--- a/wtc.py
+++ b/wtc.py
@@ -113,30 +113,40 @@ def text_output(notifications, limit: int):
         service = r.get("service_display_name")
         state = state_string(r.get("notification_state"))
 
+        if filter_notification(r):
+            if counter < limit:
+                table.add_row(
+                        f"{counter+1:02d}",
+                        timestamp,
+                        state,
+                        hostname,
+                        service
+                    )
+                counter += 1
 
-        if r.get("notification_contact_name") != None:
-            if args.filter.match(r.get("notification_contact_name")):
-                if counter < limit:
-                    table.add_row(
-                            f"{counter+1:02d}",
-                            timestamp,
-                            state,
-                            hostname,
-                            service
-                        )
-                    counter += 1
+            else:
+                break
 
-                else:
-                    break
-    
     console.print(table)
+
+def filter_notification(notification):
+    if notification.get("notification_contact_name") != None:
+        if args.filter.match(notification.get("notification_contact_name")):
+            return True
+    return False
 
 def check_input(notifications):
     print('press enter to refresh or enter a entry number to open the check in the web browser (using xdg-open):')
     user_input = input('([0-9]|q)> ')
 
     if match('[0-9]+', user_input):
-        url = notifications[int(user_input)].get('url')
+        counter = 0
+        for r in notifications:
+            if filter_notification(r):
+                counter += 1
+                if counter == int(user_input):
+                    url = r.get('url')
+                    break
         if not args.show_urls:
             subprocess.run(['xdg-open', url])
         else:

--- a/wtc.py
+++ b/wtc.py
@@ -255,5 +255,3 @@ if __name__ == "__main__":
                 check_input(notifs)
         except KeyboardInterrupt:
             exit(0)
-    else:
-        show_data()

--- a/wtc.py
+++ b/wtc.py
@@ -112,7 +112,6 @@ def text_output(notifications, limit: int):
         hostname = r.get("host_name")
         service = r.get("service_display_name")
         state = state_string(r.get("notification_state"))
-        # print(r.get("notification_state"))
 
 
         if r.get("notification_contact_name") != None:


### PR DESCRIPTION
- use "rich" library to format the table output
- use xdg-open to open check URLs in the default browser instead of displaying these

apart from that i changed around the "wait" option a bit. There are now three modes:
- the wait mode now only refreshes in regular intervals for output to a projector or large screen in the office for example
- the interactive mode which does only refresh on command (by pressing enter) - this one can be left running and after a call you can switch to the window, refresh it and open the monitoring page in the browser from there
- a "onetime" mode similar to the old non-wait mode - on execution wtc lists the last few calls and exits automatically